### PR TITLE
Roll back memcached? pattern matching.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    memflash (2.2.0)
+    memflash (2.2.1)
       actionpack (>= 4.2.11, < 5.1)
 
 GEM
@@ -32,7 +32,7 @@ GEM
     erubis (2.7.0)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    loofah (2.5.0)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     metaclass (0.0.4)

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    memflash (2.2.0)
+    memflash (2.2.1)
       actionpack (>= 4.2.11, < 5.1)
 
 GEM

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    memflash (2.2.0)
+    memflash (2.2.1)
       actionpack (>= 4.2.11, < 5.1)
 
 GEM
@@ -32,7 +32,7 @@ GEM
     erubis (2.7.0)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    loofah (2.5.0)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     metaclass (0.0.4)

--- a/lib/memflash.rb
+++ b/lib/memflash.rb
@@ -32,7 +32,7 @@ module Memflash
     end
 
     def memflashed?(key, value)
-      /^Memflash-#{key}/.match? value
+      !!(value =~ /^Memflash-#{key}/)
     end
   end
 end

--- a/memflash.gemspec
+++ b/memflash.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "memflash", "2.2.0" do |s|
+Gem::Specification.new "memflash", "2.2.1" do |s|
   s.summary = "Memflash is a gem which enables storing really long values in the Rails FlashHash without writing them to the session"
   s.description = "Memflash is a gem which enables storing really long values in the Rails FlashHash without writing them to the session. Instead, it transparently uses `Rails.cache`, thus enabling the flash in your actions to contain large values, and still fit in a cookie-based session store"
   s.email = "vladimir@zendesk.com"

--- a/test/memflash_test.rb
+++ b/test/memflash_test.rb
@@ -20,6 +20,14 @@ describe Memflash do
         end
       end
 
+      describe "shorter than Memflash.threshold" do
+        it "not affect the cache" do
+          @hash[:hello] = true
+
+          assert_equal true, @hash[:hello]
+        end
+      end
+
       describe "at least as long as Memflash.threshold" do
         before do
           @key = "a-sample-key"


### PR DESCRIPTION
Causing errors because some people are putting booleans in the flash.

The old code did `true =~ /whatever/` which is false.
The new code did `/whatever/.match? true` which is a type error.