### PR TITLE
Add workflow for pushing to Ruby Gems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish Gem
+
+on:
+  push:
+    tags: v*
+
+    jobs:
+      call-workflow:
+        uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+        secrets:
+          RUBY_GEMS_API_KEY: { secrets.RUBY_GEMS_API_KEY }
+          RUBY_GEMS_TOTP_DEVICE: { secrets.RUBY_GEMS_TOTP_DEVICE }

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
 
+# Pushing to rubygems is handled by a github workflow
+ENV['gem_push'] = 'false'
+
 require 'rake/testtask'
 Rake::TestTask.new do |test|
   test.pattern = 'test/**/*_test.rb'


### PR DESCRIPTION
Creates a workflow for publishing to the public Zendesk RubyGems account.

Uses the workflow from the public Symbol’s value as variable is void: gw gem. Symbol’s value as variable is void: gw's (ruby-gem-publication readme](https://github.com/zendesk/gw/blob/main/ruby-gem-publication/README.md)